### PR TITLE
refactor: migrate to uv for Python dependency management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Node dependencies
         run: pnpm install
       - name: Install Python dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: Run tests
         run: uv run tox
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Powered by [DKCutter](https://github.com/ncontiero/dkcutter), DKCutter Django is
 
 ## Usage
 
+> [!NOTE]
+> It is recommended to have [uv](https://docs.astral.sh/uv/getting-started/installation/) installed if you are on Windows or do not have Docker.
+
 To scaffold an application using [dkcutter](https://github.com/ncontiero/dkcutter), run any of the following four commands and answer the command prompt questions:
 
 ### npm

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,4 +20,9 @@ function ignoreFiles(files) {
 
 export default ncontiero({
   ignores: [".venv", "venv", ...(ignoreFiles(FILES_TO_IGNORE) || [])],
+  toml: {
+    overrides: {
+      "toml/indent": ["error", 4],
+    },
+  },
 });

--- a/hooks/postGenProject.ts
+++ b/hooks/postGenProject.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { execaSync } from "execa";
 import fs from "fs-extra";
 
 import { toBoolean } from "./utils/coerce";
@@ -320,6 +321,61 @@ function removeApiStarterFiles() {
   removeFiles(apiStarterFiles);
 }
 
+function setupDependencies() {
+  logger.info("Installing dependencies, this might take a while...");
+
+  const uvDockerFolderPath = path.join(
+    projectRootDir,
+    "compose",
+    "local",
+    "uv",
+  );
+  const uvDockerImagePath = path.join(uvDockerFolderPath, "Dockerfile");
+  const uvImageTag = "dkcutter-django-uv-runner:latest";
+  const uvCmdArgs = ["run", "--rm", "-v", ".:/app", uvImageTag, "uv", "add"];
+
+  try {
+    execaSync(
+      "docker",
+      ["build", "-t", uvImageTag, "-f", uvDockerImagePath, "-q", "."],
+      { stdio: "inherit" },
+    );
+  } catch (error) {
+    logger.error(`Failed to build Docker image: ${error}`);
+    process.exit(1);
+  }
+
+  // Install production dependencies
+  try {
+    execaSync(
+      "docker",
+      [...uvCmdArgs, "--no-sync", "-r", "requirements/production.txt"],
+      { stdio: "inherit" },
+    );
+  } catch (error) {
+    logger.error(`Failed to install production dependencies: ${error}`);
+    process.exit(1);
+  }
+
+  // Install local (development) dependencies
+  try {
+    execaSync(
+      "docker",
+      [...uvCmdArgs, "--no-sync", "--dev", "-r", "requirements/local.txt"],
+      { stdio: "inherit" },
+    );
+  } catch (error) {
+    logger.error(`Failed to install local dependencies: ${error}`);
+    process.exit(1);
+  }
+
+  // Remove the requirements directory
+  fs.removeSync(path.join(projectRootDir, "requirements"));
+  fs.removeSync(uvDockerFolderPath);
+
+  logger.success("Dependencies installed successfully.");
+}
+
 function main() {
   const gitignorePath = path.resolve(".gitignore");
 
@@ -364,6 +420,8 @@ function main() {
   }
 
   handleAutomatedDepsUpdater(context.automatedDepsUpdater);
+
+  setupDependencies();
 
   logger.success("Project initialized, keep up the good work!");
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,17 +3,17 @@ name = "dkcutter-django"
 version = "1.0.0"
 requires-python = ">=3.13,<3.14"
 classifiers = [
-  "Programming Language :: Python",
-  "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "django-upgrade==1.28.0",
-  "djlint==1.36.4",
-  "jinja2==3.1.6",
-  "ruff==0.13.0",
-  "tox==4.30.2",
-  "tox-uv==1.28.0",
+    "django-upgrade==1.28.0",
+    "djlint==1.36.4",
+    "jinja2==3.1.6",
+    "ruff==0.13.0",
+    "tox==4.30.2",
+    "tox-uv==1.28.0",
 ]
 
 [tool.djlint]

--- a/template/{{dkcutter.projectSlug}}/README.md
+++ b/template/{{dkcutter.projectSlug}}/README.md
@@ -17,7 +17,7 @@ Moved to [settings](https://github.com/ncontiero/dkcutter-django/blob/main/docs/
 - To create a **superuser account**, use this command:
 
 ```bash
-python manage.py createsuperuser
+uv run python manage.py createsuperuser
 ```
 
 ### Type checks
@@ -25,7 +25,7 @@ python manage.py createsuperuser
 Running type checks with mypy:
 
 ```bash
-mypy {{dkcutter.projectSlug}}
+uv run mypy {{dkcutter.projectSlug}}
 ```
 
 ### Test coverage
@@ -33,15 +33,15 @@ mypy {{dkcutter.projectSlug}}
 To run the tests, check your test coverage, and generate an HTML coverage report:
 
 ```bash
-coverage run -m pytest
-coverage html
-open htmlcov/index.html
+uv run coverage run -m pytest
+uv run coverage html
+uv run open htmlcov/index.html
 ```
 
 #### Running tests with pytest
 
 ```bash
-pytest
+uv run pytest
 ```
 
 {%- if dkcutter.useCelery %}
@@ -54,7 +54,7 @@ To run a celery worker:
 
 ```bash
 cd {{dkcutter.projectSlug}}
-celery -A config.celery_app worker -l info
+uv run celery -A config.celery_app worker -l info
 ```
 
 Please note: For Celery's import magic to work, it is important where the celery commands are run. If you are in the same folder with *manage.py*, you should be right.
@@ -63,14 +63,14 @@ To run [periodic tasks](https://docs.celeryq.dev/en/stable/userguide/periodic-ta
 
 ```bash
 cd {{dkcutter.projectSlug}}
-celery -A config.celery_app beat
+uv run celery -A config.celery_app beat
 ```
 
 or you can embed the beat service inside a worker with the -B option (not recommended for production use):
 
 ```bash
 cd {{dkcutter.projectSlug}}
-celery -A config.celery_app worker -B -l info
+uv run celery -A config.celery_app worker -B -l info
 ```
 
 {%- endif %}

--- a/template/{{dkcutter.projectSlug}}/compose/local/django/Dockerfile
+++ b/template/{{dkcutter.projectSlug}}/compose/local/django/Dockerfile
@@ -1,52 +1,46 @@
 # define an alias for the specific python version used in this file.
-FROM docker.io/python:3.13.7-slim-bookworm AS python
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS python
 
 # Python build stage
 FROM python AS python-build-stage
 
-ARG BUILD_ENVIRONMENT=local
+ARG APP_HOME=/app
+
+WORKDIR ${APP_HOME}
+
+# we need to move the virtualenv outside of the $APP_HOME directory because it will be overriden by the docker compose mount
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy UV_PYTHON_DOWNLOADS=0
 
 # Install apt packages
 RUN apt-get update && apt-get install --no-install-recommends -y \
   # dependencies for building Python packages
   build-essential \
   # psycopg dependencies
-  libpq-dev
-
-# Requirements are installed here to ensure they will be cached.
-COPY ./requirements .
-
-# Create Python Dependency and Sub-Dependency Wheels.
-RUN pip wheel --wheel-dir /usr/src/app/wheels \
-  -r production.txt \
-  -r ${BUILD_ENVIRONMENT}.txt
-
-
-# Python 'run' stage
-FROM python AS python-run-stage
-
-ARG BUILD_ENVIRONMENT=local
-ARG APP_HOME=/app
-
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV BUILD_ENV=${BUILD_ENVIRONMENT}
-
-# devcontainer dependencies and utils
-RUN apt-get update && apt-get install --no-install-recommends -y \
+  libpq-dev \
+  gettext \
+  wait-for-it \
+  # devcontainer dependencies and utils
   sudo git gpg gnupg gpg-agent socat ssh \
   zsh \
   curl \
   wget \
   fonts-powerline \
-  # psycopg dependencies
-  libpq-dev \
-  wait-for-it \
-  # Translations dependencies
-  gettext \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
+
+# Requirements are installed here to ensure they will be cached.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=uv.lock,target=uv.lock:rw \
+    uv sync --no-install-project
+
+COPY . ${APP_HOME}
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=uv.lock,target=uv.lock:rw \
+    uv sync
 
 # Create devcontainer user and add it to sudoers
 RUN groupadd --gid 1000 dev-user \
@@ -54,21 +48,13 @@ RUN groupadd --gid 1000 dev-user \
   && echo dev-user ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/dev-user \
   && chmod 0440 /etc/sudoers.d/dev-user
 
-WORKDIR ${APP_HOME}
+ENV PATH="/${APP_HOME}/.venv/bin:$PATH"
 
-# All absolute dir copies ignore workdir instruction. All relative dir copies are wrt to the workdir instruction
-# copy python dependency wheels from python-build-stage
-COPY --from=python-build-stage /usr/src/app/wheels /wheels/
-
-# use wheels to install python dependencies
-RUN pip install --no-cache-dir --no-index --find-links=/wheels/ /wheels/* \
-  && rm -rf /wheels/
-
-COPY --chown=dev-user:dev-user ./compose/production/django/entrypoint /entrypoint
+COPY ./compose/production/django/entrypoint /entrypoint
 RUN sed -i 's/\r$//g' /entrypoint
 RUN chmod +x /entrypoint
 
-COPY --chown=dev-user:dev-user ./compose/local/django/start /start
+COPY ./compose/local/django/start /start
 RUN sed -i 's/\r$//g' /start
 RUN chmod +x /start
 
@@ -89,10 +75,7 @@ RUN chmod +x /start-flower
 RUN wget https://gist.github.com/ncontiero/ab9fdbb2cc4b6af40ef3627d4ba968a4/raw/df2cf7829dd00549f8d7889254f5db017a10a8b8/.p10k.zsh && \
   mv ./.p10k.zsh /home/dev-user
 
-# copy application code to WORKDIR
-COPY --chown=dev-user:dev-user . ${APP_HOME}
-
-RUN chown -R dev-user:dev-user ${APP_HOME}
+RUN chown dev-user:dev-user ${APP_HOME}
 
 USER dev-user
 

--- a/template/{{dkcutter.projectSlug}}/compose/local/uv/Dockerfile
+++ b/template/{{dkcutter.projectSlug}}/compose/local/uv/Dockerfile
@@ -1,0 +1,6 @@
+
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS python
+
+ARG APP_HOME=/app
+
+WORKDIR ${APP_HOME}

--- a/template/{{dkcutter.projectSlug}}/compose/production/django/Dockerfile
+++ b/template/{{dkcutter.projectSlug}}/compose/production/django/Dockerfile
@@ -26,12 +26,13 @@ RUN npm run build
 
 {% endif -%}
 # define an alias for the specific python version used in this file.
-FROM docker.io/python:3.13.7-slim-bookworm AS python
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS python-build-stage
 
-# Python build stage
-FROM python AS python-build-stage
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy UV_PYTHON_DOWNLOADS=0
 
-ARG BUILD_ENVIRONMENT=production
+ARG APP_HOME=/app
+
+WORKDIR ${APP_HOME}
 
 # Install apt packages
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -41,33 +42,36 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libpq-dev
 
 # Requirements are installed here to ensure they will be cached.
-COPY ./requirements .
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project --no-dev
 
-# Create Python Dependency and Sub-Dependency Wheels.
-RUN pip wheel --wheel-dir /usr/src/app/wheels \
-  -r ${BUILD_ENVIRONMENT}.txt
+{%- if dkcutter.frontendPipeline in ["Rspack", "Webpack"] %}
+COPY --from=client-builder ${APP_HOME} ${APP_HOME}
+{% else %}
+COPY . ${APP_HOME}
+{%- endif %}
 
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-dev
 
 # Python 'run' stage
-FROM python AS python-run-stage
+FROM python:3.13-slim-bookworm AS python-run-stage
 
-ARG BUILD_ENVIRONMENT=production
 ARG APP_HOME=/app
-
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV BUILD_ENV=${BUILD_ENVIRONMENT}
 
 WORKDIR ${APP_HOME}
 
 RUN addgroup --system django \
   && adduser --system --ingroup django django
 
-
 # Install required system dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \
   # psycopg dependencies
-  libpq-dev \
+  libpq5 \
   # entrypoint
   wait-for-it \
   # Translations dependencies
@@ -75,15 +79,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
-
-# All absolute dir copies ignore workdir instruction. All relative dir copies are wrt to the workdir instruction
-# copy python dependency wheels from python-build-stage
-COPY --from=python-build-stage /usr/src/app/wheels /wheels/
-
-# use wheels to install python dependencies
-RUN pip install --no-cache-dir --no-index --find-links=/wheels/ /wheels/* \
-  && rm -rf /wheels/
-
 
 COPY --chown=django:django ./compose/production/django/entrypoint /entrypoint
 RUN sed -i 's/\r$//g' /entrypoint
@@ -107,12 +102,8 @@ RUN sed -i 's/\r$//g' /start-flower
 RUN chmod +x /start-flower
 {%- endif %}
 
-# copy application code to WORKDIR
-{%- if dkcutter.useTailwindcss %}
-COPY --from=client-builder --chown=django:django ${APP_HOME} ${APP_HOME}
-{% else %}
-COPY --chown=django:django . ${APP_HOME}
-{%- endif %}
+# Copy the application from the builder
+COPY --from=python-build-stage --chown=django:django ${APP_HOME} ${APP_HOME}
 
 {%- if dkcutter.cloudProvider == "None" %}
 
@@ -121,7 +112,10 @@ RUN mkdir -p ${APP_HOME}/{{ dkcutter.projectSlug }}/media
 {%- endif %}
 
 # make django owner of the WORKDIR directory as well.
-RUN chown -R django:django ${APP_HOME}
+RUN chown django:django ${APP_HOME}
+
+# Place executables in the environment at the front of the path
+ENV PATH="/app/.venv/bin:$PATH"
 
 USER django
 

--- a/template/{{dkcutter.projectSlug}}/compose/production/django/start
+++ b/template/{{dkcutter.projectSlug}}/compose/production/django/start
@@ -10,4 +10,4 @@ if [ "$NOT_COLLECT_STATIC" != "True" ]; then
   python /app/manage.py collectstatic --noinput
 fi
 
-exec /usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app
+exec gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app

--- a/template/{{dkcutter.projectSlug}}/docker-compose.local.yml
+++ b/template/{{dkcutter.projectSlug}}/docker-compose.local.yml
@@ -18,6 +18,7 @@ services:
     ports:
       - 8000:8000
     volumes:
+      - /app/.venv
       - .:/app:z
     depends_on:
       - postgres

--- a/template/{{dkcutter.projectSlug}}/eslint.config.mjs
+++ b/template/{{dkcutter.projectSlug}}/eslint.config.mjs
@@ -10,4 +10,9 @@ export default ncontiero({
       ],
     },
   },
+  toml: {
+    overrides: {
+      "toml/indent": ["error", 4],
+    },
+  },
 });

--- a/template/{{dkcutter.projectSlug}}/pyproject.toml
+++ b/template/{{dkcutter.projectSlug}}/pyproject.toml
@@ -1,3 +1,16 @@
+[project]
+name = "{{ dkcutter.projectSlug }}"
+version = "0.1.0"
+description = "{{ dkcutter.description }}"
+authors = [ { name = "{{ dkcutter.authorName }}", email = "{{ dkcutter.email }}" } ]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.13,<3.14"
+dependencies = []
+
+[dependency-groups]
+dev = []
+
 # ==== pytest ====
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/template/{{dkcutter.projectSlug}}/pyproject.toml
+++ b/template/{{dkcutter.projectSlug}}/pyproject.toml
@@ -5,7 +5,7 @@ description = "{{ dkcutter.description }}"
 authors = [ { name = "{{ dkcutter.authorName }}", email = "{{ dkcutter.email }}" } ]
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.13,<3.14"
+requires-python = "==3.13.*"
 dependencies = []
 
 [dependency-groups]

--- a/template/{{dkcutter.projectSlug}}/pyproject.toml
+++ b/template/{{dkcutter.projectSlug}}/pyproject.toml
@@ -16,8 +16,8 @@ dev = []
 minversion = "6.0"
 addopts = "--ds=config.settings.test --reuse-db --import-mode=importlib"
 python_files = [
-  "tests.py",
-  "test_*.py",
+    "tests.py",
+    "test_*.py",
 ]
 
 # ==== Coverage ====
@@ -70,71 +70,71 @@ indent_size = 2
 target-version = "py313"
 # Exclude a variety of commonly ignored directories.
 extend-exclude = [
-  "*/migrations/*.py",
-  "staticfiles/*",
+    "*/migrations/*.py",
+    "staticfiles/*",
 ]
 
 [tool.ruff.lint]
 select = [
-  "E",
-  "F",
-  "W",
-  "C90",
-  "I",
-  "N",
-  "UP",
-  "YTT",
-  # "ANN", # flake8-annotations: we should support this in the future but 100+ errors atm
-  "ASYNC",
-  "S",
-  "BLE",
-  "FBT",
-  "B",
-  "A",
-  "COM",
-  "C4",
-  "DTZ",
-  "T10",
-  "DJ",
-  "EM",
-  "EXE",
-  "FA",
-  "ISC",
-  "ICN",
-  "G",
-  "INP",
-  "PIE",
-  "T20",
-  "PYI",
-  "PT",
-  "Q",
-  "RSE",
-  "RET",
-  "SLF",
-  "SLOT",
-  "SIM",
-  "TID",
-  "TC",
-  "INT",
-  # "ARG", # Unused function argument
-  "PTH",
-  "ERA",
-  "PD",
-  "PGH",
-  "PL",
-  "TRY",
-  "FLY",
-  # "NPY",
-  # "AIR",
-  "PERF",
-  # "FURB",
-  # "LOG",
-  "RUF"
+    "E",
+    "F",
+    "W",
+    "C90",
+    "I",
+    "N",
+    "UP",
+    "YTT",
+    # "ANN", # flake8-annotations: we should support this in the future but 100+ errors atm
+    "ASYNC",
+    "S",
+    "BLE",
+    "FBT",
+    "B",
+    "A",
+    "COM",
+    "C4",
+    "DTZ",
+    "T10",
+    "DJ",
+    "EM",
+    "EXE",
+    "FA",
+    "ISC",
+    "ICN",
+    "G",
+    "INP",
+    "PIE",
+    "T20",
+    "PYI",
+    "PT",
+    "Q",
+    "RSE",
+    "RET",
+    "SLF",
+    "SLOT",
+    "SIM",
+    "TID",
+    "TC",
+    "INT",
+    # "ARG", # Unused function argument
+    "PTH",
+    "ERA",
+    "PD",
+    "PGH",
+    "PL",
+    "TRY",
+    "FLY",
+    # "NPY",
+    # "AIR",
+    "PERF",
+    # "FURB",
+    # "LOG",
+    "RUF"
 ]
 ignore = [
-  "S101", # Use of assert detected https://docs.astral.sh/ruff/rules/assert/
-  "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
-  "SIM102" # sometimes it's better to nest
+    "S101", # Use of assert detected https://docs.astral.sh/ruff/rules/assert/
+    "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
+    "SIM102" # sometimes it's better to nest
 ]
 
 [tool.ruff.lint.isort]

--- a/template/{{dkcutter.projectSlug}}/requirements.txt
+++ b/template/{{dkcutter.projectSlug}}/requirements.txt
@@ -1,1 +1,0 @@
--r requirements/production.txt

--- a/template/{{dkcutter.projectSlug}}/requirements/local.txt
+++ b/template/{{dkcutter.projectSlug}}/requirements/local.txt
@@ -1,5 +1,3 @@
--r base.txt
-
 Werkzeug[watchdog]==3.1.3  # https://github.com/pallets/werkzeug
 psycopg[binary]==3.2.10  # https://github.com/psycopg/psycopg
 {%- if dkcutter.useCelery %}

--- a/template/{{dkcutter.projectSlug}}/uv.lock
+++ b/template/{{dkcutter.projectSlug}}/uv.lock
@@ -1,0 +1,2 @@
+version = 1
+requires-python = "==3.13.*"

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -30,6 +30,10 @@ cd my_awesome_project
 # make sure all images build
 docker compose -f docker-compose.local.yml build
 
+docker compose -f docker-compose.local.yml run django uv lock
+
+docker compose -f docker-compose.local.yml build
+
 # run the project's type checks
 docker compose -f docker-compose.local.yml run --rm django mypy my_awesome_project
 
@@ -53,6 +57,22 @@ docker compose -f docker-compose.local.yml run --rm \
   -e MAILGUN_API_KEY=x \
   -e MAILGUN_DOMAIN=x \
   django python manage.py check --settings=config.settings.production --deploy --database default --fail-level WARNING
+
+docker build -f ./compose/production/django/Dockerfile -t django-prod .
+
+docker run --rm \
+  --env-file .envs/.local/.django \
+  --env-file .envs/.local/.postgres \
+  --network my_awesome_project_default \
+  -e DJANGO_SECRET_KEY="$(openssl rand -base64 64)" \
+  -e REDIS_URL=redis://redis:6379/0 \
+  -e DJANGO_AWS_ACCESS_KEY_ID=x \
+  -e DJANGO_AWS_SECRET_ACCESS_KEY=x \
+  -e DJANGO_AWS_STORAGE_BUCKET_NAME=x \
+  -e DJANGO_ADMIN_URL=x \
+  -e MAILGUN_API_KEY=x \
+  -e MAILGUN_DOMAIN=x \
+  django-prod python manage.py check --settings=config.settings.production --deploy --database default --fail-level WARNING
 
 # Run npm build script if package.json is present
 if [ -f "package.json" ]; then

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -6,9 +6,14 @@ import { PATTERN } from "./constants";
  * Build a list containing absolute paths to the generated files.
  */
 export function buildFilesList(baseDir: string) {
+  const excludedDirs = ["node_modules", ".venv", "venv", "__pycache__"];
   const files = fs.readdirSync(baseDir);
   const paths: string[] = [];
   files.forEach((file) => {
+    if (excludedDirs.includes(file)) {
+      return;
+    }
+
     const filePath = path.join(baseDir, file);
     const stat = fs.statSync(filePath);
     if (stat.isDirectory()) {


### PR DESCRIPTION
Migrate to [uv](https://docs.astral.sh/uv/):

- Replaces pip and requirements files with uv and pyproject.toml for Python dependency management.
- Updates Dockerfiles for both local and production environments to use uv-based Python images and workflows.
